### PR TITLE
Modularize scripts for better load performance

### DIFF
--- a/about.html
+++ b/about.html
@@ -85,6 +85,6 @@
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
   </footer>
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
 </body>
 </html>

--- a/contact-form.js
+++ b/contact-form.js
@@ -1,25 +1,5 @@
-// Mobile nav
-const toggle=document.querySelector('.nav-toggle');
-const menu=document.getElementById('primary-menu');
-if(toggle&&menu){toggle.addEventListener('click',()=>{const open=menu.classList.toggle('open');toggle.setAttribute('aria-expanded',String(open));});}
+'use strict';
 
-// Fade-in on scroll
-const io=new IntersectionObserver(entries=>entries.forEach(e=>{if(e.isIntersecting)e.target.classList.add('in')}),{threshold:.14});
-document.querySelectorAll('.fade').forEach(el=>io.observe(el));
-
-// Active nav
-(function(){const page=document.body.dataset.page;if(!page)return;
-  const link=document.querySelector(`.nav-list a[href="${page}.html"], .nav-list a[href="${page}"]`);
-  if(link){link.classList.add('active');link.setAttribute('aria-current','page');}
-})();
-
-// Reading progress (for long pages)
-(function(){const bar=document.querySelector('.progressbar');if(!bar)return;
-  const onScroll=()=>{const h=document.documentElement;const max=h.scrollHeight-h.clientHeight;const pct=max?(h.scrollTop/max)*100:0;bar.style.width=pct+'%';};
-  document.addEventListener('scroll',onScroll,{passive:true});onScroll();
-})();
-
-// ===== SMART FORM WIZARD =====
 (function(){
   const form = document.getElementById('contact-form-smart');
   if(!form) return;
@@ -27,7 +7,7 @@ document.querySelectorAll('.fade').forEach(el=>io.observe(el));
   // Autosave
   const KEY='rbis_contact_draft_v1';
   const saveDraft=()=>{const data=Object.fromEntries(new FormData(form)); localStorage.setItem(KEY,JSON.stringify(data));};
-  const loadDraft=()=>{try{const d=JSON.parse(localStorage.getItem(KEY)||'{}'); for(const k in d){const el=form.elements[k]; if(!el) continue; if(el.type==='checkbox' || el.type==='radio'){if(Array.isArray(d[k])){[...form.elements[k]].forEach(opt=>{opt.checked=d[k].includes(opt.value);});}else{el.checked=!!d[k];}} else el.value=d[k];} }catch{}
+  const loadDraft=()=>{try{const d=JSON.parse(localStorage.getItem(KEY)||'{}'); for(const k in d){const el=form.elements[k]; if(!el) continue; if(el.type==='checkbox' || el.type==='radio'){if(Array.isArray(d[k])){[...form.elements[k]].forEach(opt=>{opt.checked=d[k].includes(opt.value);});}else{el.checked=!!d[k];}} else el.value=d[k];}}catch(e){}};
   const clearDraft=()=>localStorage.removeItem(KEY);
 
   loadDraft();
@@ -158,3 +138,4 @@ document.querySelectorAll('.fade').forEach(el=>io.observe(el));
   });
 
 })();
+

--- a/contact.html
+++ b/contact.html
@@ -230,6 +230,7 @@
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
   </footer>
 
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
+  <script src="contact-form.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -144,6 +144,6 @@
   </footer>
 
   <div class="sticky-cta"><span>Need rapid support?</span><a class="btn btn-primary" href="contact.html">Contact RBIS</a></div>
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
 </body>
 </html>

--- a/insights.html
+++ b/insights.html
@@ -75,6 +75,6 @@
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
   </footer>
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,48 @@
+'use strict';
+
+(() => {
+  const toggle = document.querySelector('.nav-toggle');
+  const menu = document.getElementById('primary-menu');
+  if (toggle && menu) {
+    toggle.addEventListener('click', () => {
+      const open = menu.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', String(open));
+    });
+  }
+})();
+
+(() => {
+  const io = new IntersectionObserver(entries =>
+    entries.forEach(e => {
+      if (e.isIntersecting) e.target.classList.add('in');
+    }),
+    { threshold: 0.14 }
+  );
+  document.querySelectorAll('.fade').forEach(el => io.observe(el));
+})();
+
+(() => {
+  const page = document.body.dataset.page;
+  if (!page) return;
+  const link = document.querySelector(
+    `.nav-list a[href="${page}.html"], .nav-list a[href="${page}"]`
+  );
+  if (link) {
+    link.classList.add('active');
+    link.setAttribute('aria-current', 'page');
+  }
+})();
+
+(() => {
+  const bar = document.querySelector('.progressbar');
+  if (!bar) return;
+  const onScroll = () => {
+    const h = document.documentElement;
+    const max = h.scrollHeight - h.clientHeight;
+    const pct = max ? (h.scrollTop / max) * 100 : 0;
+    bar.style.width = pct + '%';
+  };
+  document.addEventListener('scroll', onScroll, { passive: true });
+  onScroll();
+})();
+

--- a/rbis-system.html
+++ b/rbis-system.html
@@ -120,6 +120,6 @@
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
   </footer>
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
 </body>
 </html>

--- a/sectors.html
+++ b/sectors.html
@@ -66,6 +66,6 @@
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
   </footer>
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -100,6 +100,6 @@
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
   </footer>
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
 </body>
 </html>

--- a/workflow.html
+++ b/workflow.html
@@ -92,6 +92,6 @@
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
   </footer>
-  <script src="script.js"></script>
+  <script src="main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- split common JavaScript into `main.js` and contact-form logic
- defer script loading on all pages for faster rendering
- remove legacy `script.js`

## Testing
- `node -c main.js`
- `node -c contact-form.js`
- `npx htmlhint '*.html'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a39023148322b21abbe31415f823