### PR TITLE
Add Jest tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/__tests__/LegalHub.test.jsx
+++ b/__tests__/LegalHub.test.jsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import LegalHub from '../src/LegalHub';
+
+test('renders Privacy Policy section', () => {
+  render(<LegalHub />);
+  expect(screen.getByText(/Privacy Policy/i)).toBeInTheDocument();
+});

--- a/__tests__/contact-form.test.js
+++ b/__tests__/contact-form.test.js
@@ -1,0 +1,15 @@
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <form id="contact-form-smart">
+      <input name="ttc" />
+    </form>
+    <div id="form-status"></div>
+  `;
+});
+
+test('initialises ttc field', async () => {
+  await import('../contact-form.js');
+  const val = document.querySelector('input[name="ttc"]').value;
+  expect(val).not.toBe('');
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  },
+  moduleFileExtensions: ['js', 'jsx'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "rbisuk.github.io",
+  "version": "1.0.0",
+  "description": "RBIS UK site",
+  "main": "main.js",
+  "scripts": {
+    "test": "jest",
+    "build": "echo \"build\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@babel/core": "^7.23.0",
+    "@babel/preset-env": "^7.23.0",
+    "@babel/preset-react": "^7.23.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.0.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up Jest with basic build and test scripts
- add minimal tests for contact form script and Legal Hub component
- run tests and build on each commit via GitHub Actions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c186811ce083229af9ee6d9dbcad06