### PR TITLE
Fix scrollIntoView call in contact form

### DIFF
--- a/contact-form.js
+++ b/contact-form.js
@@ -29,7 +29,8 @@
     idx = Math.max(0, Math.min(steps.length-1, i));
     steps.forEach((s,j)=>{s.style.display = j===idx?'block':'none';});
     bullets.forEach((b,j)=>{b.classList.toggle('active', j<=idx);});
-    form.scrollIntoView({behavior:'smooth', block:'start'});
+    // scrollIntoView is not implemented in jsdom used for tests
+    form.scrollIntoView?.({behavior:'smooth', block:'start'});
   }
 
   setStep(0);


### PR DESCRIPTION
## Summary
- Guard `scrollIntoView` call in contact-form logic so tests don't crash when API unavailable

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18d0c83c883229271389239ece0be