### PR TITLE
Add deploy job for GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: ['**']
   pull_request:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,3 +20,16 @@ jobs:
           node-version: 20
       - run: npm install
       - run: npm run build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- configure workflow permissions for GitHub Pages deployment
- add deploy job uploading site and deploying to GitHub Pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `git push origin main` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a27bad7c83229a0f35cda3a237e6