### PR TITLE
Remove unused build script and workflow steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm install
-      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "RBIS UK site",
   "main": "main.js",
-  "scripts": {
-    "build": "echo \"build\""
-  },
   "keywords": [],
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
## Summary
- remove placeholder build script from package.json
- simplify CI workflow by dropping Node setup and build command

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1a2809dc8832283bc87feba400997