### PR TITLE
Add legal and 404 pages to fix broken links

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Page Not Found — RBIS</title>
+  <meta name="description" content="The requested page could not be found."/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css"/><link rel="icon" href="favicon.ico"/>
+</head>
+<body>
+  <header class="site-header">
+    <a class="skip-link" href="#main">Skip to content</a>
+    <div class="container nav-wrap">
+      <a class="brand" href="index.html">RBIS</a>
+    </div>
+  </header>
+
+  <main id="main" class="section">
+    <div class="container center stack gap-16">
+      <h1 class="display">Page Not Found</h1>
+      <p class="muted max-640">The page you're looking for doesn't exist or has been moved.</p>
+      <a class="btn btn-primary" href="index.html">Back to Home</a>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services.</small></div>
+  </footer>
+  <script src="main.js" defer></script>
+</body>
+</html>

--- a/about.html
+++ b/about.html
@@ -79,7 +79,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="#" aria-disabled="true">Privacy Policy</a><a href="#" aria-disabled="true">Terms of Service</a><a href="#" aria-disabled="true">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>

--- a/contact.html
+++ b/contact.html
@@ -185,7 +185,7 @@
                 <div class="field" data-required="true">
                   <label class="check-line">
                     <input type="checkbox" name="consent" id="consent" required/>
-                    <span>I agree to the <a href="/legal#privacy" target="_blank" rel="noopener">Privacy Policy</a> and <a href="/legal#terms" target="_blank" rel="noopener">Terms of Service</a>.</span>
+                    <span>I agree to the <a href="legal.html#privacy" target="_blank" rel="noopener">Privacy Policy</a> and <a href="legal.html#terms" target="_blank" rel="noopener">Terms of Service</a>.</span>
                   </label>
                   <div class="error">Consent is required to proceed.</div>
                 </div>
@@ -229,7 +229,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="/legal#privacy">Privacy Policy</a><a href="/legal#terms">Terms of Service</a><a href="/legal#nda">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="/legal#privacy">Privacy Policy</a><a href="/legal#terms">Terms of Service</a><a href="/legal#nda">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>

--- a/insights.html
+++ b/insights.html
@@ -70,7 +70,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="#" aria-disabled="true">Privacy Policy</a><a href="#" aria-disabled="true">Terms of Service</a><a href="#" aria-disabled="true">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>

--- a/legal.html
+++ b/legal.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Legal — RBIS</title>
+  <meta name="description" content="Privacy policy, terms of service, and confidentiality agreement."/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css"/><link rel="icon" href="favicon.ico"/>
+</head>
+<body data-page="legal">
+  <header class="site-header">
+    <a class="skip-link" href="#main">Skip to content</a>
+    <div class="container nav-wrap">
+      <a class="brand" href="index.html">RBIS</a>
+      <nav class="nav" aria-label="Primary">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu"><span class="sr-only">Toggle navigation</span><div class="hamburger"></div></button>
+        <ul id="primary-menu" class="nav-list">
+          <li><a class="nav-link" href="index.html">Home</a></li>
+          <li><a class="nav-link" href="about.html">About</a></li>
+          <li><a class="nav-link" href="services.html">Services</a></li>
+          <li><a class="nav-link" href="rbis-system.html">RBIS System</a></li>
+          <li><a class="nav-link" href="workflow.html">Workflow</a></li>
+          <li><a class="nav-link" href="sectors.html">Sectors</a></li>
+          <li><a class="nav-link" href="contact.html">Contact</a></li>
+          <li><a class="nav-link" href="insights.html">Insights</a></li>
+        </ul>
+      </nav>
+      <div class="nav-cta"><a class="btn btn-primary" href="contact.html">Get Consultation</a></div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section">
+      <div class="container prose stack gap-32">
+        <h1 class="display">Legal Information</h1>
+
+        <section id="privacy" class="stack gap-12">
+          <h2 class="h2">Privacy Policy</h2>
+          <p>We collect and process personal data only to respond to enquiries and deliver services. Information is stored securely and never shared with third parties without consent.</p>
+        </section>
+
+        <section id="terms" class="stack gap-12">
+          <h2 class="h2">Terms of Service</h2>
+          <p>Use of this website signifies agreement to use the provided information responsibly and not to reproduce content without permission.</p>
+        </section>
+
+        <section id="nda" class="stack gap-12">
+          <h2 class="h2">Confidentiality Agreement</h2>
+          <p>All communications and materials provided to RBIS are treated as confidential. Non-disclosure agreements are available on request for sensitive engagements.</p>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container grid-footer">
+      <div class="stack gap-12"><div class="brand">Ryan Roberts Behavioural &amp; Intelligence Services</div>
+        <p class="muted small max-640">Specialising in forensic behavioural and intelligence analysis with precision, confidentiality, and legal defensibility.</p></div>
+      <nav class="stack gap-8" aria-label="Quick Links"><strong>Quick Links</strong>
+        <a href="index.html">Home</a><a href="about.html">About</a><a href="services.html">Services</a><a href="rbis-system.html">RBIS System</a>
+        <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
+      </nav>
+      <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
+      </nav>
+    </div>
+    <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>
+  </footer>
+  <script src="main.js" defer></script>
+</body>
+</html>

--- a/rbis-system.html
+++ b/rbis-system.html
@@ -114,7 +114,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="#" aria-disabled="true">Privacy Policy</a><a href="#" aria-disabled="true">Terms of Service</a><a href="#" aria-disabled="true">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>

--- a/sectors.html
+++ b/sectors.html
@@ -61,7 +61,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="#" aria-disabled="true">Privacy Policy</a><a href="#" aria-disabled="true">Terms of Service</a><a href="#" aria-disabled="true">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>

--- a/services.html
+++ b/services.html
@@ -95,7 +95,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="#" aria-disabled="true">Privacy Policy</a><a href="#" aria-disabled="true">Terms of Service</a><a href="#" aria-disabled="true">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>

--- a/workflow.html
+++ b/workflow.html
@@ -87,7 +87,7 @@
         <a href="workflow.html">Workflow</a><a href="sectors.html">Sectors</a><a href="contact.html">Contact</a><a href="insights.html">Insights</a>
       </nav>
       <nav class="stack gap-8" aria-label="Legal"><strong>Legal</strong>
-        <a href="#" aria-disabled="true">Privacy Policy</a><a href="#" aria-disabled="true">Terms of Service</a><a href="#" aria-disabled="true">Confidentiality Agreement</a>
+        <a href="legal.html#privacy">Privacy Policy</a><a href="legal.html#terms">Terms of Service</a><a href="legal.html#nda">Confidentiality Agreement</a>
       </nav>
     </div>
     <div class="container footer-base"><small>© 2024 Ryan Roberts Behavioural &amp; Intelligence Services. All rights reserved.</small></div>


### PR DESCRIPTION
## Summary
- add standalone legal page with privacy policy, terms, and confidentiality sections
- add custom 404 page with link back to home
- point footer and consent links to new legal page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1a6d63af08322927076fcf9bae641