### PR TITLE
Sanitize contact form fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,8 +188,10 @@
 <script>
   (function(){const k='rbis_consent'; if(!localStorage.getItem(k)) document.getElementById('cookie').style.display='block';
     window.cookieSet=function(mode){localStorage.setItem(k, JSON.stringify({necessary:true, analytics: mode==='analytics'})); document.getElementById('cookie').style.display='none';};})();
+  function sanitizeEmailField(str){return (str||'').replace(/[\r\n]/g,'').replace(/[&<>"']/g,c=>'&#'+c.charCodeAt(0)+';');}
   function contactSubmit(e){e.preventDefault(); const f=e.target, d=new FormData(f);
-    const body='Name: '+(d.get('name')||'')+'\nEmail: '+(d.get('email')||'')+'\nLegal review requested: '+(d.get('legal_review')?'Yes':'No')+'\n\n'+(d.get('message')||'');
+    const name=sanitizeEmailField(d.get('name')), email=sanitizeEmailField(d.get('email')), message=sanitizeEmailField(d.get('message'));
+    const body='Name: '+name+'\nEmail: '+email+'\nLegal review requested: '+(d.get('legal_review')?'Yes':'No')+'\n\n'+message;
     window.location.href='mailto:Contact@RBISIntelligence.com?subject=RBIS%20Enquiry&body='+encodeURIComponent(body); f.reset(); return false;}
   function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
   (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();


### PR DESCRIPTION
## Summary
- Add `sanitizeEmailField` helper to strip CR/LF and encode special characters.
- Sanitize `name`, `email`, and `message` fields before constructing mail body.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c203d4b2208322a3efdc6581540c36