### PR TITLE
Refactor footer spacing into shared stylesheet

### DIFF
--- a/dashboards.html
+++ b/dashboards.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>RBIS — Executive Dashboards</title>
 <meta name="description" content="RBIS dashboards: CEO Command, Board & Crisis, Live Ops, Investor Flight Deck."/>
+<link rel="stylesheet" href="style.css"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
 <style>
   :root{--bg:#ffffff;--ink:#0f172a;--muted:#475569;--line:#e2e8f0;--soft:#f8fafc;--brand:#0b132b;--brand2:#1c2541;--brand3:#3a506b;--accent:#118ab2;--ok:#16a34a;--warn:#d97706;--bad:#dc2626;--r:16px;--p:18px;--shadow:0 18px 30px -20px rgba(0,0,0,.25)}
@@ -129,8 +130,8 @@
   </section>
 </div>
 
-<footer style="border-top:1px solid var(--line);margin-top:26px">
-  <div class="wrap" style="text-align:center;color:var(--muted);padding:20px 0">
+<footer>
+  <div class="wrap">
     © <span id="year"></span> RBIS — Behavioural & Intelligence Services • <a href="trust.html">Trust</a> • <a href="legal.html">Legal</a>
   </div>
 </footer>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <title>RBIS — Behavioural & Intelligence Services</title>
 <meta name="description" content="RBIS equips leaders with foresight, clarity, and behavioural advantage — through independent analysis and intelligence-grade, court-ready reports."/>
 <meta name="theme-color" content="#0b132b"/>
+<link rel="stylesheet" href="style.css"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
 <style>
   :root{
@@ -47,7 +48,6 @@
   .muted{color:var(--muted)}
   .notice{background:#eef4ff;border:1px solid var(--line);border-radius:12px;padding:12px}
   .control{margin-top:6px;border-top:1px dashed var(--line);padding-top:6px;color:var(--muted);font-size:12px}
-  footer{border-top:1px solid var(--line);padding:26px 0;background:#fff;color:var(--muted)}
   #cookie{display:none;position:sticky;bottom:0;background:#fff;border-top:1px solid var(--line);padding:10px 0;z-index:60}
   .evc-badge{display:none}
   body.evidence-mode .marketing{display:none}
@@ -178,9 +178,9 @@
   </div>
 </section>
 <footer>
-  <div class="wrap" style="text-align:center">
+  <div class="wrap">
     <div>© <span id="year"></span> RBIS — Behavioural & Intelligence Services</div>
-    <div style="margin-top:8px;display:flex;gap:12px;justify-content:center;flex-wrap:wrap">
+    <div class="footer-links">
       <a href="legal.html#legal-privacy">Privacy</a><a href="legal.html#legal-cookies">Cookies</a><a href="legal.html#legal-terms">Terms</a><a href="legal.html#legal-security">Security</a><a href="legal.html#legal-retention">Data Retention</a><a href="legal.html#legal-nda">NDA</a><a href="legal.html#legal-claims">Claims</a><a href="legal.html#legal-dpa">DPA</a>
     </div>
   </div>

--- a/legal.html
+++ b/legal.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>RBIS — Legal Hub</title>
 <meta name="description" content="RBIS Legal Hub: Privacy, Terms, NDA, Retention, Security, Cookies, Claims, DPA."/>
+<link rel="stylesheet" href="style.css"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
 <style>
   :root{--bg:#ffffff;--ink:#0f172a;--muted:#475569;--line:#e2e8f0;--soft:#f8fafc;--brand:#0b132b;--brand3:#3a506b;--accent:#118ab2;--r:16px;--p:18px;--shadow:0 18px 30px -20px rgba(0,0,0,.25)}
@@ -128,8 +129,8 @@
   </section>
 </div>
 
-<footer style="border-top:1px solid var(--line);margin-top:26px">
-  <div class="wrap" style="text-align:center;color:var(--muted);padding:20px 0">
+<footer>
+  <div class="wrap">
     © <span id="year"></span> RBIS — Behavioural & Intelligence Services • <a href="#legal-privacy">Privacy</a> • <a href="#legal-terms">Terms</a>
   </div>
 </footer>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,15 @@
+footer{
+  margin-top:20px;
+  padding:20px 0;
+  border-top:1px solid var(--line);
+  background:#fff;
+  color:var(--muted);
+  text-align:center;
+}
+footer .footer-links{
+  margin-top:8px;
+  display:flex;
+  gap:12px;
+  justify-content:center;
+  flex-wrap:wrap;
+}

--- a/trust.html
+++ b/trust.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>RBIS — Trust & Assurance Centre</title>
 <meta name="description" content="RBIS Trust & Assurance: commitments, compliance matrix, policy ledger, and certified extracts."/>
+<link rel="stylesheet" href="style.css"/>
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
 <style>
   :root{--bg:#ffffff;--ink:#0f172a;--muted:#475569;--line:#e2e8f0;--soft:#f8fafc;--brand:#0b132b;--brand3:#3a506b;--accent:#118ab2;--r:16px;--p:18px;--shadow:0 18px 30px -20px rgba(0,0,0,.25)}
@@ -89,8 +90,8 @@
     </div>
   </section>
 </div>
-<footer style="border-top:1px solid var(--line);margin-top:26px">
-  <div class="wrap" style="text-align:center;color:var(--muted);padding:20px 0">
+<footer>
+  <div class="wrap">
     © <span id="year"></span> RBIS — Behavioural & Intelligence Services • <a href="legal.html#legal-privacy">Privacy</a> • <a href="legal.html#legal-terms">Terms</a>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Move footer margin and padding rules into a new shared stylesheet with compact defaults
- Remove inline `margin-top` attributes from page footers and link all pages to the shared styles

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c21f93e9b48322845e888318320ea3