### PR TITLE
style: centralize button styling and replace currency formatter alias

### DIFF
--- a/dashboards.html
+++ b/dashboards.html
@@ -17,9 +17,6 @@
   .brand img{height:34px;width:auto}
   .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
   .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)} .menu a:hover{background:var(--soft)}
-  .btn,.btn-ghost{cursor:pointer}
-  .btn{display:inline-block;background:var(--brand3);color:#fff;border-radius:12px;padding:10px 14px;text-decoration:none;border:1px solid #0f233b;box-shadow:var(--shadow);font-weight:600}
-  .btn-ghost{display:inline-block;background:#fff;color:var(--ink);border:1px solid var(--line);border-radius:12px;padding:8px 12px}
   h1{font-size:clamp(26px,4vw,40px);margin:22px 0 12px} h2{font-size:clamp(22px,2.6vw,32px);margin:22px 0 10px} h3{font-size:20px;margin:14px 0 8px}
   .section{padding:30px 0} .card{background:#fff;border:1px solid var(--line);border-radius:var(--r);padding:var(--p);box-shadow:var(--shadow)}
   .grid{display:grid;gap:16px} .grid-2{grid-template-columns:repeat(2,minmax(0,1fr))} .grid-3{grid-template-columns:repeat(3,minmax(0,1fr))} @media (max-width:980px){.grid-3,.grid-2{grid-template-columns:1fr}}
@@ -40,7 +37,7 @@
       <a href="dashboards.html">Dashboards</a>
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
-      <label class="btn-ghost" style="cursor:pointer">
+      <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
       <button class="btn-ghost" onclick="setPeriod('Q1')">Q1</button>
@@ -148,7 +145,7 @@
     kanban:{intake:['Tenant case: damp/mould','HR dispute: comms audit','Council enquiry: timeline'],analysis:['Audio review: tone markers','Doc auth: timestamp variance'],reporting:['Forensic report: Housing (v1.2)','Compliance memo: Processor review']},
     finance:{marginPct:32,runwayMonths:14}
   };
-  const £=n=>'£'+n.toLocaleString('en-GB');
+  const formatGBP = n => '£' + n.toLocaleString('en-GB');
   function clamp(n,min,max){return Math.max(min,Math.min(max,n))}
   function sum(a){return a.reduce((x,y)=>x+y,0)}
   function avg(a){return a.length?sum(a)/a.length:0}
@@ -173,8 +170,8 @@ function render(){
     document.querySelectorAll(".section").forEach(s=>s.style.display="");
   }
   const revK=sum(d.revenue)*1000, arrK=d.arr[d.arr.length-1]*1000, winK=avg(d.winRate);
-  document.getElementById("kpiRevenue").textContent=£(revK);
-  document.getElementById("kpiARR").textContent=£(arrK);
+  document.getElementById("kpiRevenue").textContent=formatGBP(revK);
+  document.getElementById("kpiARR").textContent=formatGBP(arrK);
   document.getElementById("kpiWin").textContent=Math.round(winK)+"%";
   document.getElementById("gRevenue").style.width=clamp((revK/(sum(data.revenue)*1000))*100,5,100)+"%";
   document.getElementById("gARR").style.width=clamp((arrK/(data.arr[data.arr.length-1]*1000))*100,5,100)+"%";

--- a/index.html
+++ b/index.html
@@ -26,10 +26,6 @@
   .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
   .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)}
   .menu a:hover{background:var(--soft)}
-  .btn,.btn-ghost{cursor:pointer}
-  .btn{display:inline-block;background:var(--brand3);color:#fff;border-radius:12px;padding:10px 14px;text-decoration:none;border:1px solid #0f233b;box-shadow:var(--shadow);font-weight:600}
-  .btn:hover{filter:brightness(1.05)}
-  .btn-ghost{display:inline-block;background:#fff;color:var(--ink);border:1px solid var(--line);border-radius:12px;padding:8px 12px}
   .badge{display:inline-block;border:1px solid var(--line);background:var(--soft);border-radius:999px;padding:4px 8px;font-size:12px}
   header.hero{background:linear-gradient(180deg,#fff,#f3f6fb 56%,#fff);border-bottom:1px solid var(--line)}
   header.hero .wrap{display:grid;grid-template-columns:1.2fr .8fr;gap:26px;padding:56px 0}
@@ -79,7 +75,7 @@
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
       <a href="#contact" class="btn marketing">Contact</a>
-      <label class="btn-ghost" style="cursor:pointer">
+      <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
     </div>

--- a/legal.html
+++ b/legal.html
@@ -16,8 +16,6 @@
   .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:20px;color:var(--brand)}
   .brand img{height:34px;width:auto}
   .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center} .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)} .menu a:hover{background:var(--soft)}
-  .btn,.btn-ghost{cursor:pointer}
-  .btn-ghost{display:inline-block;background:#fff;color:var(--ink);border:1px solid var(--line);border-radius:12px;padding:8px 12px}
   h1{font-size:clamp(26px,4vw,40px);margin:22px 0 8px} h2{font-size:clamp(22px,2.6vw,30px);margin:22px 0 10px} h3{font-size:19px;margin:12px 0 6px}
   .section{padding:30px 0} .card{background:#fff;border:1px solid var(--line);border-radius:var(--r);padding:var(--p);box-shadow:var(--shadow)}
   .grid{display:grid;gap:16px} .navcol{grid-template-columns:260px 1fr} @media (max-width:980px){.navcol{grid-template-columns:1fr}}
@@ -37,7 +35,7 @@
       <a href="dashboards.html">Dashboards</a>
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
-      <label class="btn-ghost" style="cursor:pointer">
+      <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
     </div>

--- a/style.css
+++ b/style.css
@@ -1,3 +1,51 @@
+.btn,
+.btn-ghost{
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:600;
+  border-radius:12px;
+  text-decoration:none;
+  transition:filter .15s, background-color .15s, transform .1s;
+}
+
+.btn{
+  padding:10px 14px;
+  background:var(--brand3);
+  color:#fff;
+  border:1px solid #0f233b;
+  box-shadow:var(--shadow);
+}
+
+.btn:hover,
+.btn:focus-visible{
+  filter:brightness(1.05);
+}
+
+.btn-ghost{
+  padding:8px 12px;
+  background:#fff;
+  color:var(--ink);
+  border:1px solid var(--line);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus-visible{
+  background:var(--soft);
+}
+
+.btn:focus-visible,
+.btn-ghost:focus-visible{
+  outline:2px solid var(--accent);
+  outline-offset:2px;
+}
+
+.btn:active,
+.btn-ghost:active{
+  transform:scale(.98);
+}
+
 footer{
   margin-top:20px;
   padding:20px 0;

--- a/trust.html
+++ b/trust.html
@@ -17,9 +17,6 @@
   .brand img{height:34px;width:auto}
   .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
   .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)} .menu a:hover{background:var(--soft)}
-  .btn,.btn-ghost{cursor:pointer}
-  .btn{display:inline-block;background:var(--brand3);color:#fff;border-radius:12px;padding:10px 14px;text-decoration:none;border:1px solid #0f233b;box-shadow:var(--shadow);font-weight:600}
-  .btn-ghost{display:inline-block;background:#fff;color:var(--ink);border:1px solid var(--line);border-radius:12px;padding:8px 12px}
   h1{font-size:clamp(26px,4vw,40px);margin:22px 0 8px} h2{font-size:clamp(22px,2.6vw,32px);margin:26px 0 10px} h3{font-size:20px;margin:14px 0 8px}
   .section{padding:34px 0} .card{background:#fff;border:1px solid var(--line);border-radius:var(--r);padding:var(--p);box-shadow:var(--shadow)}
   .grid{display:grid;gap:16px} .grid-3{grid-template-columns:repeat(3,minmax(0,1fr))} @media (max-width:980px){.grid-3{grid-template-columns:1fr}}
@@ -39,7 +36,7 @@
       <a href="dashboards.html">Dashboards</a>
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
-      <label class="btn-ghost" style="cursor:pointer">
+      <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
     </div>


### PR DESCRIPTION
## Summary
- replace currency formatter alias with named function
- centralize button styling with shared classes and interactive states

## Testing
- `node -e "const formatGBP=n=>'£'+n.toLocaleString('en-GB'); console.log(formatGBP(1234));"`
- `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/dashboards.html`
- `curl -I http://localhost:8000/trust.html`
- `curl -I http://localhost:8000/legal.html`
- ⚠️ `npx playwright --version` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c22324fca08322aac6bd39dacb82b1