### PR TITLE
Improve mobile layout and card overflow handling

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,3 +61,17 @@ footer .footer-links{
   justify-content:center;
   flex-wrap:wrap;
 }
+/* Layout utilities */
+.grid{display:grid;gap:16px;}
+.grid-2{grid-template-columns:repeat(2,minmax(0,1fr));}
+.grid-3{grid-template-columns:repeat(3,minmax(0,1fr));}
+.section{padding:44px 0;}
+.card{background:#fff;border:1px solid var(--line);border-radius:var(--r);padding:var(--p);box-shadow:var(--shadow);}
+
+@media (max-width:980px){
+  .grid-2,.grid-3{grid-template-columns:1fr !important;}
+  .wrap{padding:0 16px !important;}
+  .section{padding:30px 0 !important;}
+  h1,h2{margin-top:20px !important;margin-bottom:10px !important;}
+  .card{max-height:400px;overflow:auto;}
+}


### PR DESCRIPTION
## Summary
- Add grid utilities and responsive breakpoints to ensure cards stack under 980px
- Provide max-height and overflow controls for card content on small screens
- Reduce heading and section spacing for cleaner mobile layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a7105d648322849ecce5965f9830