### PR TITLE
Add dedicated services, software, and contact pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>RBIS — Contact</title>
+<meta name="description" content="Engage RBIS for confidential consulting and intelligence."/>
+<link rel="stylesheet" href="style.css"/>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
+<style>
+  :root{--bg:#ffffff;--ink:#0f172a;--muted:#475569;--line:#e2e8f0;--soft:#f8fafc;--brand:#0b132b;--brand2:#1c2541;--brand3:#3a506b;--accent:#118ab2;--ok:#16a34a;--warn:#d97706;--bad:#dc2626;--r:16px;--p:18px;--shadow:0 18px 30px -20px rgba(0,0,0,.25)}
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.6 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
+  a{color:var(--accent)} img{max-width:100%;height:auto}
+  .wrap{max-width:1200px;margin-inline:auto;padding:0 20px}
+  .nav{position:sticky;top:0;z-index:50;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+  .nav .wrap{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:20px;color:var(--brand)}
+  .brand img{height:34px;width:auto}
+  .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
+  .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)}
+  .menu a:hover{background:var(--soft)}
+  h1{font-size:clamp(26px,4vw,40px);margin:22px 0 12px}
+  h2{font-size:clamp(22px,2.6vw,32px);margin:30px 0 12px}
+  h3{font-size:20px;margin:16px 0 8px}
+  p{margin:0 0 12px;color:var(--muted)}
+  .section{padding:44px 0}
+  .card{background:#fff;border:1px solid var(--line);border-radius:var(--r);padding:var(--p);box-shadow:var(--shadow)}
+  .grid{display:grid;gap:16px}
+  .grid-2{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .control{margin-top:6px;border-top:1px dashed var(--line);padding-top:6px;color:var(--muted);font-size:12px}
+  @media (max-width:980px){.grid-2{grid-template-columns:1fr}}
+  @media print{nav{display:none !important}.card{page-break-inside:avoid}a:after{content:" (" attr(href) ")";font-size:11px;color:#64748b}}
+</style>
+</head>
+<body>
+<nav class="nav">
+  <div class="wrap">
+    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <div class="menu">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
+      <a href="dashboards.html">Dashboards</a>
+      <a href="trust.html">Trust</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
+      <label class="btn-ghost">
+        <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
+      </label>
+    </div>
+  </div>
+</nav>
+<div class="wrap">
+  <h1>Contact RBIS</h1>
+  <section class="section grid grid-2">
+    <div>
+      <p>Email: <a href="mailto:Contact@RBISIntelligence.com">Contact@RBISIntelligence.com</a></p>
+      <form id="contactForm" class="card" method="post" action="mailto:Contact@RBISIntelligence.com" enctype="text/plain" onsubmit="return contactSubmit(event)">
+        <p><label>Name<br><input name="name" required type="text" style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></label></p>
+        <p><label>Email<br><input name="email" required type="email" style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></label></p>
+        <p><label>Message<br><textarea name="message" rows="5" required style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></textarea></label></p>
+        <p style="font-size:13px" class="control">I agree to confidential processing per the <a href="legal.html#legal-privacy">Privacy</a> and <a href="legal.html#legal-terms">Terms</a>. Mark for legal review <input type="checkbox" name="legal_review"></p>
+        <p><button class="btn" type="submit">Send</button></p>
+        <p class="control">Avoid submitting unnecessary special category data. Email is not end-to-end encrypted.</p>
+      </form>
+    </div>
+    <div>
+      <div class="card">
+        <h3>Address</h3><p>PO Box, Bournemouth, Dorset, BH2 5RR, England</p>
+        <h3>Operating Region</h3><p>England & Wales (UK GDPR)</p>
+      </div>
+    </div>
+  </section>
+</div>
+<footer>
+  <div class="wrap">
+    <div>© <span id="year"></span> RBIS — Behavioural & Intelligence Services</div>
+    <div class="footer-links">
+      <a href="legal.html#legal-privacy">Privacy</a><a href="legal.html#legal-cookies">Cookies</a><a href="legal.html#legal-terms">Terms</a><a href="legal.html#legal-security">Security</a><a href="legal.html#legal-retention">Data Retention</a><a href="legal.html#legal-nda">NDA</a><a href="legal.html#legal-claims">Claims</a><a href="legal.html#legal-dpa">DPA</a>
+    </div>
+  </div>
+</footer>
+<script>
+  function sanitizeEmailField(str){return (str||'').replace(/[\r\n]/g,'').replace(/[&<>"']/g,c=>'&#'+c.charCodeAt(0)+';');}
+  function contactSubmit(e){e.preventDefault(); const f=e.target, d=new FormData(f);
+    const name=sanitizeEmailField(d.get('name')), email=sanitizeEmailField(d.get('email')), message=sanitizeEmailField(d.get('message'));
+    const body='Name: '+name+'\nEmail: '+email+'\nLegal review requested: '+(d.get('legal_review')?'Yes':'No')+'\n\n'+message;
+    window.location.href='mailto:Contact@RBISIntelligence.com?subject=RBIS%20Enquiry&body='+encodeURIComponent(body); f.reset(); return false;}
+  function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
+  (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>
+

--- a/dashboards.html
+++ b/dashboards.html
@@ -34,9 +34,12 @@
     <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
     <div class="menu">
       <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
       <a href="dashboards.html">Dashboards</a>
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>

--- a/index.html
+++ b/index.html
@@ -71,10 +71,12 @@
     <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
     <div class="menu">
       <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
       <a href="dashboards.html">Dashboards</a>
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
-      <a href="#contact" class="btn marketing">Contact</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
@@ -87,7 +89,7 @@
       <span class="badge">Authority • Confidentiality • Precision</span>
       <h1>RBIS equips leaders with foresight, clarity, and behavioural advantage — through independent analysis and intelligence-grade, court-ready reports.</h1>
       <div style="display:flex;gap:10px;margin-top:10px">
-        <a class="btn" href="#contact">Engage RBIS</a>
+        <a class="btn" href="contact.html">Engage RBIS</a>
         <a class="btn" style="background:#1c2541" href="legal.html">Legal Hub</a>
       </div>
       <div class="control">RBIS applies court-ready standards to intake, chain of custody, and analyst review. See <a href="trust.html">Trust Centre</a>.</div>
@@ -134,42 +136,23 @@
       </ul>
     </div>
   </div>
-</section>
+ </section>
 <section class="section marketing">
-  <div class="wrap">
-    <h2>Services & Solutions</h2>
-    <div class="grid grid-3">
-      <div class="card"><h3>Evidence Handling & Verification</h3><ul style="padding-left:18px"><li>Secure intake • encrypted submission • GDPR consent</li><li>Forensic normalisation & integrity checks</li></ul><div class="control">UK GDPR-compliant controls apply.</div></div>
-      <div class="card"><h3>AI-Assisted Behavioural Analysis</h3><ul style="padding-left:18px"><li>Sentiment/tone • pattern recognition</li><li>Timeline mapping • anomaly detection</li></ul><div class="control">Analyst validation required before reporting.</div></div>
-      <div class="card"><h3>Human Forensic Review</h3><ul style="padding-left:18px"><li>Independent verification</li><li>Cross-source corroboration</li><li>Defensible methodology</li></ul></div>
+  <div class="wrap grid grid-3">
+    <div class="card">
+      <h2>Services & Solutions</h2>
+      <p>Evidence handling, AI-assisted analysis, and human forensic review.</p>
+      <p><a href="services.html">Explore services →</a></p>
     </div>
-    <h3 style="margin-top:18px">Bespoke Software</h3>
-    <div class="grid grid-3">
-      <div class="card"><h3>Repairs & Compliance Copilot</h3><p>Multi-tenant copilot for housing providers: SLA timers, automated comms, evidence packs.</p></div>
-      <div class="card"><h3>PACT Ledger</h3><p>Promise OS converting commitments into evidence-backed objects; court-ready exports.</p></div>
-      <div class="card"><h3>OmniAssist Platform</h3><p>Config-driven, modular workflows across repairs, compliance, and sales. Role-based control.</p></div>
+    <div class="card">
+      <h2>Bespoke Software</h2>
+      <p>Copilots and platforms built for compliance and operations.</p>
+      <p><a href="software.html">Explore software →</a></p>
     </div>
-  </div>
-</section>
-<section id="contact" class="section">
-  <div class="wrap grid grid-2">
-    <div>
+    <div class="card">
       <h2>Contact RBIS</h2>
-      <p>Email: <a href="mailto:Contact@RBISIntelligence.com">Contact@RBISIntelligence.com</a></p>
-      <form id="contactForm" class="card" method="post" action="mailto:Contact@RBISIntelligence.com" enctype="text/plain" onsubmit="return contactSubmit(event)">
-        <p><label>Name<br><input name="name" required type="text" style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></label></p>
-        <p><label>Email<br><input name="email" required type="email" style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></label></p>
-        <p><label>Message<br><textarea name="message" rows="5" required style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></textarea></label></p>
-        <p style="font-size:13px" class="control">I agree to confidential processing per the <a href="legal.html#legal-privacy">Privacy</a> and <a href="legal.html#legal-terms">Terms</a>. Mark for legal review <input type="checkbox" name="legal_review"></p>
-        <p><button class="btn" type="submit">Send</button></p>
-        <p class="control">Avoid submitting unnecessary special category data. Email is not end-to-end encrypted.</p>
-      </form>
-    </div>
-    <div>
-      <div class="card">
-        <h3>Address</h3><p>PO Box, Bournemouth, Dorset, BH2 5RR, England</p>
-        <h3>Operating Region</h3><p>England & Wales (UK GDPR)</p>
-      </div>
+      <p>Engage our team for confidential consulting and intelligence.</p>
+      <p><a href="contact.html">Get in touch →</a></p>
     </div>
   </div>
 </section>
@@ -184,11 +167,6 @@
 <script>
   (function(){const k='rbis_consent'; if(!localStorage.getItem(k)) document.getElementById('cookie').style.display='block';
     window.cookieSet=function(mode){localStorage.setItem(k, JSON.stringify({necessary:true, analytics: mode==='analytics'})); document.getElementById('cookie').style.display='none';};})();
-  function sanitizeEmailField(str){return (str||'').replace(/[\r\n]/g,'').replace(/[&<>"']/g,c=>'&#'+c.charCodeAt(0)+';');}
-  function contactSubmit(e){e.preventDefault(); const f=e.target, d=new FormData(f);
-    const name=sanitizeEmailField(d.get('name')), email=sanitizeEmailField(d.get('email')), message=sanitizeEmailField(d.get('message'));
-    const body='Name: '+name+'\nEmail: '+email+'\nLegal review requested: '+(d.get('legal_review')?'Yes':'No')+'\n\n'+message;
-    window.location.href='mailto:Contact@RBISIntelligence.com?subject=RBIS%20Enquiry&body='+encodeURIComponent(body); f.reset(); return false;}
   function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
   (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
   document.getElementById('year').textContent = new Date().getFullYear();

--- a/legal.html
+++ b/legal.html
@@ -32,9 +32,12 @@
     <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
     <div class="menu">
       <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
       <a href="dashboards.html">Dashboards</a>
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>RBIS — Services & Solutions</title>
+<meta name="description" content="Evidence handling, behavioural analysis, and human forensic review."/>
+<link rel="stylesheet" href="style.css"/>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
+<style>
+  :root{--bg:#ffffff;--ink:#0f172a;--muted:#475569;--line:#e2e8f0;--soft:#f8fafc;--brand:#0b132b;--brand2:#1c2541;--brand3:#3a506b;--accent:#118ab2;--ok:#16a34a;--warn:#d97706;--bad:#dc2626;--r:16px;--p:18px;--shadow:0 18px 30px -20px rgba(0,0,0,.25)}
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.6 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
+  a{color:var(--accent)} img{max-width:100%;height:auto}
+  .wrap{max-width:1200px;margin-inline:auto;padding:0 20px}
+  .nav{position:sticky;top:0;z-index:50;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+  .nav .wrap{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:20px;color:var(--brand)}
+  .brand img{height:34px;width:auto}
+  .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
+  .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)}
+  .menu a:hover{background:var(--soft)}
+  h1{font-size:clamp(26px,4vw,40px);margin:22px 0 12px}
+  h2{font-size:clamp(22px,2.6vw,32px);margin:30px 0 12px}
+  h3{font-size:20px;margin:16px 0 8px}
+  p{margin:0 0 12px;color:var(--muted)}
+  .section{padding:44px 0}
+  .card{background:#fff;border:1px solid var(--line);border-radius:var(--r);padding:var(--p);box-shadow:var(--shadow)}
+  .grid{display:grid;gap:16px}
+  .grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .control{margin-top:6px;border-top:1px dashed var(--line);padding-top:6px;color:var(--muted);font-size:12px}
+  @media (max-width:980px){.grid-3{grid-template-columns:1fr}}
+  @media print{nav{display:none !important}.card{page-break-inside:avoid}a:after{content:" (" attr(href) ")";font-size:11px;color:#64748b}}
+</style>
+</head>
+<body>
+<nav class="nav">
+  <div class="wrap">
+    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <div class="menu">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
+      <a href="dashboards.html">Dashboards</a>
+      <a href="trust.html">Trust</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
+      <label class="btn-ghost">
+        <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
+      </label>
+    </div>
+  </div>
+</nav>
+<div class="wrap">
+  <h1>Services & Solutions</h1>
+  <section class="section">
+    <div class="grid grid-3">
+      <div class="card"><h3>Evidence Handling & Verification</h3><ul style="padding-left:18px"><li>Secure intake • encrypted submission • GDPR consent</li><li>Forensic normalisation & integrity checks</li></ul><div class="control">UK GDPR-compliant controls apply.</div></div>
+      <div class="card"><h3>AI-Assisted Behavioural Analysis</h3><ul style="padding-left:18px"><li>Sentiment/tone • pattern recognition</li><li>Timeline mapping • anomaly detection</li></ul><div class="control">Analyst validation required before reporting.</div></div>
+      <div class="card"><h3>Human Forensic Review</h3><ul style="padding-left:18px"><li>Independent verification</li><li>Cross-source corroboration</li><li>Defensible methodology</li></ul></div>
+    </div>
+  </section>
+</div>
+<footer>
+  <div class="wrap">
+    <div>© <span id="year"></span> RBIS — Behavioural & Intelligence Services</div>
+    <div class="footer-links">
+      <a href="legal.html#legal-privacy">Privacy</a><a href="legal.html#legal-cookies">Cookies</a><a href="legal.html#legal-terms">Terms</a><a href="legal.html#legal-security">Security</a><a href="legal.html#legal-retention">Data Retention</a><a href="legal.html#legal-nda">NDA</a><a href="legal.html#legal-claims">Claims</a><a href="legal.html#legal-dpa">DPA</a>
+    </div>
+  </div>
+</footer>
+<script>
+  function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
+  (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>
+

--- a/software.html
+++ b/software.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>RBIS — Software</title>
+<meta name="description" content="Copilots and platforms built for compliance and operations."/>
+<link rel="stylesheet" href="style.css"/>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
+<style>
+  :root{--bg:#ffffff;--ink:#0f172a;--muted:#475569;--line:#e2e8f0;--soft:#f8fafc;--brand:#0b132b;--brand2:#1c2541;--brand3:#3a506b;--accent:#118ab2;--ok:#16a34a;--warn:#d97706;--bad:#dc2626;--r:16px;--p:18px;--shadow:0 18px 30px -20px rgba(0,0,0,.25)}
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.6 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
+  a{color:var(--accent)} img{max-width:100%;height:auto}
+  .wrap{max-width:1200px;margin-inline:auto;padding:0 20px}
+  .nav{position:sticky;top:0;z-index:50;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+  .nav .wrap{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:20px;color:var(--brand)}
+  .brand img{height:34px;width:auto}
+  .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
+  .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)}
+  .menu a:hover{background:var(--soft)}
+  h1{font-size:clamp(26px,4vw,40px);margin:22px 0 12px}
+  h3{font-size:20px;margin:16px 0 8px}
+  p{margin:0 0 12px;color:var(--muted)}
+  .section{padding:44px 0}
+  .card{background:#fff;border:1px solid var(--line);border-radius:var(--r);padding:var(--p);box-shadow:var(--shadow)}
+  .grid{display:grid;gap:16px}
+  .grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
+  @media (max-width:980px){.grid-3{grid-template-columns:1fr}}
+  @media print{nav{display:none !important}.card{page-break-inside:avoid}a:after{content:" (" attr(href) ")";font-size:11px;color:#64748b}}
+</style>
+</head>
+<body>
+<nav class="nav">
+  <div class="wrap">
+    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <div class="menu">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
+      <a href="dashboards.html">Dashboards</a>
+      <a href="trust.html">Trust</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
+      <label class="btn-ghost">
+        <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
+      </label>
+    </div>
+  </div>
+</nav>
+<div class="wrap">
+  <h1>Bespoke Software</h1>
+  <section class="section">
+    <div class="grid grid-3">
+      <div class="card"><h3>Repairs & Compliance Copilot</h3><p>Multi-tenant copilot for housing providers: SLA timers, automated comms, evidence packs.</p></div>
+      <div class="card"><h3>PACT Ledger</h3><p>Promise OS converting commitments into evidence-backed objects; court-ready exports.</p></div>
+      <div class="card"><h3>OmniAssist Platform</h3><p>Config-driven, modular workflows across repairs, compliance, and sales. Role-based control.</p></div>
+    </div>
+  </section>
+</div>
+<footer>
+  <div class="wrap">
+    <div>© <span id="year"></span> RBIS — Behavioural & Intelligence Services</div>
+    <div class="footer-links">
+      <a href="legal.html#legal-privacy">Privacy</a><a href="legal.html#legal-cookies">Cookies</a><a href="legal.html#legal-terms">Terms</a><a href="legal.html#legal-security">Security</a><a href="legal.html#legal-retention">Data Retention</a><a href="legal.html#legal-nda">NDA</a><a href="legal.html#legal-claims">Claims</a><a href="legal.html#legal-dpa">DPA</a>
+    </div>
+  </div>
+</footer>
+<script>
+  function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
+  (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>
+

--- a/trust.html
+++ b/trust.html
@@ -33,9 +33,12 @@
     <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
     <div class="menu">
       <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
       <a href="dashboards.html">Dashboards</a>
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>


### PR DESCRIPTION
## Summary
- Split services, software, and contact sections into standalone pages.
- Updated navigation across the site to include new pages.
- Simplified homepage with brief links to detailed sections.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a70b71ec8322a31f79921cc0088d