### PR TITLE
Add contact API endpoint and AJAX submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Push to `main` → auto-deploys to **GitHub Pages** via Actions.
 
 ## Local preview
 
-Open any HTML file directly in a browser or serve this repository with any static file server. No build step or runtime dependencies are required.
+Run `npm install` to fetch dependencies, then `npm start` to launch the Express server with the `/api/contact` endpoint. The server expects SMTP configuration via environment variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`).

--- a/index.html
+++ b/index.html
@@ -155,15 +155,16 @@
   <div class="wrap grid grid-2">
     <div>
       <h2>Contact RBIS</h2>
-      <p>Email: <a href="mailto:Contact@RBISIntelligence.com">Contact@RBISIntelligence.com</a></p>
-      <form id="contactForm" class="card" method="post" action="mailto:Contact@RBISIntelligence.com" enctype="text/plain" onsubmit="return contactSubmit(event)">
+        <p>Email: Contact@RBISIntelligence.com</p>
+        <form id="contactForm" class="card" method="post" action="/api/contact" onsubmit="return contactSubmit(event)">
         <p><label>Name<br><input name="name" required type="text" style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></label></p>
         <p><label>Email<br><input name="email" required type="email" style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></label></p>
         <p><label>Message<br><textarea name="message" rows="5" required style="width:100%;padding:10px;border:1px solid var(--line);border-radius:10px"></textarea></label></p>
         <p style="font-size:13px" class="control">I agree to confidential processing per the <a href="legal.html#legal-privacy">Privacy</a> and <a href="legal.html#legal-terms">Terms</a>. Mark for legal review <input type="checkbox" name="legal_review"></p>
-        <p><button class="btn" type="submit">Send</button></p>
-        <p class="control">Avoid submitting unnecessary special category data. Email is not end-to-end encrypted.</p>
-      </form>
+          <p><button class="btn" type="submit">Send</button></p>
+          <p id="contactStatus" class="control"></p>
+          <p class="control">Avoid submitting unnecessary special category data. Email is not end-to-end encrypted.</p>
+        </form>
     </div>
     <div>
       <div class="card">
@@ -184,11 +185,38 @@
 <script>
   (function(){const k='rbis_consent'; if(!localStorage.getItem(k)) document.getElementById('cookie').style.display='block';
     window.cookieSet=function(mode){localStorage.setItem(k, JSON.stringify({necessary:true, analytics: mode==='analytics'})); document.getElementById('cookie').style.display='none';};})();
-  function sanitizeEmailField(str){return (str||'').replace(/[\r\n]/g,'').replace(/[&<>"']/g,c=>'&#'+c.charCodeAt(0)+';');}
-  function contactSubmit(e){e.preventDefault(); const f=e.target, d=new FormData(f);
-    const name=sanitizeEmailField(d.get('name')), email=sanitizeEmailField(d.get('email')), message=sanitizeEmailField(d.get('message'));
-    const body='Name: '+name+'\nEmail: '+email+'\nLegal review requested: '+(d.get('legal_review')?'Yes':'No')+'\n\n'+message;
-    window.location.href='mailto:Contact@RBISIntelligence.com?subject=RBIS%20Enquiry&body='+encodeURIComponent(body); f.reset(); return false;}
+  async function contactSubmit(e){
+    e.preventDefault();
+    const f=e.target;
+    const d=new FormData(f);
+    const status=document.getElementById('contactStatus');
+    status.textContent='Sending...';
+    try{
+      const res=await fetch(f.action,{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({
+          name:d.get('name'),
+          email:d.get('email'),
+          message:d.get('message'),
+          legal_review:!!d.get('legal_review')
+        })
+      });
+      if(res.ok){
+        status.textContent='Message sent.';
+        status.style.color='var(--ok)';
+        f.reset();
+      }else{
+        const err=await res.json().catch(()=>({}));
+        status.textContent=err.error||'Failed to send.';
+        status.style.color='var(--bad)';
+      }
+    }catch(err){
+      status.textContent='Network error.';
+      status.style.color='var(--bad)';
+    }
+    return false;
+  }
   function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
   (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
   document.getElementById('year').textContent = new Date().getFullYear();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rbis-site",
+  "version": "1.0.0",
+  "description": "RBIS website backend server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.10.0",
+    "nodemailer": "^6.9.8"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+const nodemailer = require('nodemailer');
+
+const app = express();
+
+// Rate limiting: 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+});
+app.use(limiter);
+
+app.use(express.json());
+
+function validateEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+app.post('/api/contact', async (req, res) => {
+  const { name, email, message, legal_review } = req.body || {};
+  if (typeof name !== 'string' || !name.trim()) {
+    return res.status(400).json({ error: 'Name is required.' });
+  }
+  if (!validateEmail(email)) {
+    return res.status(400).json({ error: 'Valid email is required.' });
+  }
+  if (typeof message !== 'string' || !message.trim()) {
+    return res.status(400).json({ error: 'Message is required.' });
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  const text = `Name: ${name}\nEmail: ${email}\nLegal review requested: ${legal_review ? 'Yes' : 'No'}\n\n${message}`;
+
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to: 'Contact@RBISIntelligence.com',
+      subject: 'RBIS Website Enquiry',
+      text,
+    });
+    console.log('Contact message sent from', email);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Contact send error', err);
+    res.status(500).json({ error: 'Failed to send message.' });
+  }
+});
+
+// Optional: serve static files when running locally
+app.use(express.static('.'));
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- add Express server with `/api/contact` endpoint, input validation, logging and rate limiting
- move contact form to AJAX POST and display status messages
- document server usage and dependencies

## Testing
- `npm test`
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_68c2a708ec2c83228a313a17518a5dd5