### PR TITLE
Add theme toggle with persistent preference

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -45,6 +45,7 @@
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
       <a href="contact.html" class="btn marketing">Contact</a>
+      <button id="themeToggle" class="btn-ghost">Dark Mode</button>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
@@ -89,8 +90,9 @@
     window.location.href='mailto:Contact@RBISIntelligence.com?subject=RBIS%20Enquiry&body='+encodeURIComponent(body); f.reset(); return false;}
   function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
   (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-  document.getElementById('year').textContent = new Date().getFullYear();
-</script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+  <script src="js/theme-toggle.js"></script>
 </body>
 </html>
 

--- a/dashboards.html
+++ b/dashboards.html
@@ -7,4 +7,5 @@
   <meta name="description" content="RBIS dashboards: CEO Command, Board & Crisis, Live Ops, Investor Flight Deck."/>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
   <link rel="stylesheet" href="style.css"/>
+  <script src="js/theme-toggle.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -8,4 +8,5 @@
   <meta name="theme-color" content="#0b132b"/>
   <link rel="stylesheet" href="style.css"/>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
+  <script src="js/theme-toggle.js"></script>
 </head>

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,33 @@
+(function(){
+  const STORAGE_KEY = 'rbis_theme';
+  const root = document.documentElement;
+  const btn = document.getElementById('themeToggle');
+
+  function applyTheme(theme){
+    if(theme === 'dark'){
+      root.setAttribute('data-theme','dark');
+    } else {
+      root.removeAttribute('data-theme');
+    }
+    localStorage.setItem(STORAGE_KEY, theme);
+    if(btn){
+      btn.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+      btn.setAttribute('aria-pressed', theme === 'dark');
+    }
+  }
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if(stored){
+    applyTheme(stored);
+  } else if(btn){
+    btn.textContent = 'Dark Mode';
+    btn.setAttribute('aria-pressed', 'false');
+  }
+
+  if(btn){
+    btn.addEventListener('click', function(){
+      const isDark = root.getAttribute('data-theme') === 'dark';
+      applyTheme(isDark ? 'light' : 'dark');
+    });
+  }
+})();

--- a/legal.html
+++ b/legal.html
@@ -38,6 +38,7 @@
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
       <a href="contact.html" class="btn marketing">Contact</a>
+      <button id="themeToggle" class="btn-ghost">Dark Mode</button>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
@@ -142,8 +143,9 @@
     document.body.classList.toggle('evidence-mode', on);
     localStorage.setItem('rbis_evc', JSON.stringify(!!on));
   }
-  (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-  document.getElementById('year').textContent = new Date().getFullYear();
-</script>
+    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+  <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -45,6 +45,7 @@
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
       <a href="contact.html" class="btn marketing">Contact</a>
+      <button id="themeToggle" class="btn-ghost">Dark Mode</button>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
@@ -71,9 +72,10 @@
 </footer>
 <script>
   function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-  (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-  document.getElementById('year').textContent = new Date().getFullYear();
-</script>
+    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+  <script src="js/theme-toggle.js"></script>
 </body>
 </html>
 

--- a/services/ai-assisted-behavioural-analysis.html
+++ b/services/ai-assisted-behavioural-analysis.html
@@ -21,5 +21,6 @@
     <p>Outputs are advisory and require human validation before any decision is made. Models are trained on anonymised data and operate under documented UK GDPR legitimate-interest assessments.</p>
     <p><a href="../index.html#services">Back to services</a></p>
   </main>
-</body>
-</html>
+  <script src="../js/theme-toggle.js"></script>
+  </body>
+  </html>

--- a/services/evidence-handling.html
+++ b/services/evidence-handling.html
@@ -21,5 +21,6 @@
     <p>All submissions follow UK GDPR consent and minimisation principles. Chain‑of‑custody logs, hashing, and controlled retention policies enable courtroom admissibility and client audits.</p>
     <p><a href="../index.html#services">Back to services</a></p>
   </main>
-</body>
-</html>
+  <script src="../js/theme-toggle.js"></script>
+  </body>
+  </html>

--- a/services/human-forensic-review.html
+++ b/services/human-forensic-review.html
@@ -21,5 +21,6 @@
     <p>RBIS reviewers operate under confidentiality agreements and apply documented quality‑assurance steps. Evidence is handled in line with retention schedules and access controls to satisfy UK GDPR and criminal procedure rules.</p>
     <p><a href="../index.html#services">Back to services</a></p>
   </main>
-</body>
-</html>
+  <script src="../js/theme-toggle.js"></script>
+  </body>
+  </html>

--- a/software.html
+++ b/software.html
@@ -43,6 +43,7 @@
       <a href="trust.html">Trust</a>
       <a href="legal.html">Legal</a>
       <a href="contact.html" class="btn marketing">Contact</a>
+      <button id="themeToggle" class="btn-ghost">Dark Mode</button>
       <label class="btn-ghost">
         <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
       </label>
@@ -69,9 +70,10 @@
 </footer>
 <script>
   function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-  (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-  document.getElementById('year').textContent = new Date().getFullYear();
-</script>
+    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+  <script src="js/theme-toggle.js"></script>
 </body>
 </html>
 

--- a/solutions/omniassist-platform.html
+++ b/solutions/omniassist-platform.html
@@ -21,5 +21,6 @@
     <p>Role‑based access controls, audit logging, and encryption are enabled by default. Tenant‑specific configuration allows controllers to implement their own retention schedules and privacy notices.</p>
     <p><a href="../index.html#services">Back to services</a></p>
   </main>
-</body>
-</html>
+  <script src="../js/theme-toggle.js"></script>
+  </body>
+  </html>

--- a/solutions/pact-ledger.html
+++ b/solutions/pact-ledger.html
@@ -21,5 +21,6 @@
     <p>The ledger maintains immutable audit trails while respecting subject rights through export and erasure workflows. Data is compartmentalised by project and secured with encryption at rest and in transit.</p>
     <p><a href="../index.html#services">Back to services</a></p>
   </main>
-</body>
-</html>
+  <script src="../js/theme-toggle.js"></script>
+  </body>
+  </html>

--- a/solutions/repairs-copilot.html
+++ b/solutions/repairs-copilot.html
@@ -21,5 +21,6 @@
     <p>All tenant data is processed under controller instructions with role‑based access controls and audit logs. Configurable retention rules and exportable records support UK Housing Ombudsman and GDPR requirements.</p>
     <p><a href="../index.html#services">Back to services</a></p>
   </main>
-</body>
-</html>
+  <script src="../js/theme-toggle.js"></script>
+  </body>
+  </html>

--- a/trust.html
+++ b/trust.html
@@ -7,4 +7,5 @@
   <meta name="description" content="RBIS Trust & Assurance: commitments, compliance matrix, policy ledger, and certified extracts."/>
   <link rel="stylesheet" href="style.css"/>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
+  <script src="js/theme-toggle.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Add reusable `theme-toggle.js` that toggles a dark theme via `data-theme` and saves preference in `localStorage`.
- Insert "Dark Mode" button into site navigation and load the theme toggle script on every page.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c2ba2ff97083229c9540b579aad35a