### PR TITLE
Document optional build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Push to `main` → auto-deploys to **GitHub Pages** via Actions.
 - `legal.html` — Legal Hub
 - `dashboards.html` — interactive executive dashboards (CSV export and Evidence Pack)
 
+## Optional build
+
+Install dependencies and minify HTML/CSS into `dist/` for a production build:
+
+```bash
+npm install
+npm run minify
+```
+
+The `dist/` directory will contain the optimized site output.
+
 ## Local preview
 
-Open any HTML file directly in a browser or serve this repository with any static file server. No build step or runtime dependencies are required.
+Open any HTML file directly in a browser or serve this repository with any static file server. Local preview works without running the optional build step or installing dependencies.


### PR DESCRIPTION
## Summary
- document optional `npm install` and `npm run minify` workflow
- note that build output is written to `dist/`
- clarify that local preview works without building

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c2ba3945508322870026880eef4af5