### PR TITLE
Add meta descriptions for service and solution pages

### DIFF
--- a/services/ai-assisted-behavioural-analysis.html
+++ b/services/ai-assisted-behavioural-analysis.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>AI-Assisted Behavioural Analysis — RBIS</title>
+  <meta name="description" content="Combines machine learning and human analysis to interpret tone, intent, and behavioural signals across large datasets."/>
   <link rel="stylesheet" href="../style.css"/>
 </head>
 <body>

--- a/services/evidence-handling.html
+++ b/services/evidence-handling.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Evidence Handling & Verification — RBIS</title>
+  <meta name="description" content="Processes digital and physical evidence with tamper-evident workflows to preserve provenance for compliant investigations."/>
   <link rel="stylesheet" href="../style.css"/>
 </head>
 <body>

--- a/services/human-forensic-review.html
+++ b/services/human-forensic-review.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Human Forensic Review — RBIS</title>
+  <meta name="description" content="Experienced analysts deliver defensible findings through rigorous evidence review and transparent methodology."/>
   <link rel="stylesheet" href="../style.css"/>
 </head>
 <body>

--- a/solutions/omniassist-platform.html
+++ b/solutions/omniassist-platform.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>OmniAssist Platform — RBIS</title>
+  <meta name="description" content="Configurable workflows across repairs, compliance and customer service via a unified data layer."/>
   <link rel="stylesheet" href="../style.css"/>
 </head>
 <body>

--- a/solutions/pact-ledger.html
+++ b/solutions/pact-ledger.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>PACT Ledger — RBIS</title>
+  <meta name="description" content="Immutable ledger recording organisational commitments with timestamps, ownership and linked evidence for accountability."/>
   <link rel="stylesheet" href="../style.css"/>
 </head>
 <body>

--- a/solutions/repairs-copilot.html
+++ b/solutions/repairs-copilot.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Repairs & Compliance Copilot — RBIS</title>
+  <meta name="description" content="Monitors repairs and statutory inspections in real time, automating communications, scheduling and evidence generation for compliance."/>
   <link rel="stylesheet" href="../style.css"/>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add page-specific meta descriptions for AI-Assisted Behavioural Analysis, Evidence Handling & Verification, and Human Forensic Review
- add meta descriptions for OmniAssist Platform, PACT Ledger, and Repairs & Compliance Copilot solution pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c2ba3401ec83229dcdd14d6834484d