### PR TITLE
Add body with navigation and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,3 +10,26 @@
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
   <script src="js/theme-toggle.js"></script>
 </head>
+<body id="top">
+  <nav>
+    <ul>
+      <li><a href="#top">Home</a></li>
+      <li><a href="#services">Services</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ul>
+  </nav>
+  <main>
+    <section id="services">
+      <h2>Services</h2>
+      <p>Explore our range of services tailored to your needs.</p>
+    </section>
+    <section id="contact">
+      <h2>Contact</h2>
+      <p><a href="contact.html">Get in touch</a></p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2024 RBIS</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add body layout containing navigation links to Home, Services, and Contact sections
- include main content sections for Services and Contact with corresponding IDs and a footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python3 -m http.server` *(served index.html at http://localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c83e1f208322aa2681188a21cdd0