### PR TITLE
Fix service page scripts and add navigation links

### DIFF
--- a/services.html
+++ b/services.html
@@ -32,9 +32,9 @@
   <h1>Services & Solutions</h1>
   <section class="section">
     <div class="grid grid-3">
-      <div class="card"><h3>Evidence Handling & Verification</h3><ul style="padding-left:18px"><li>Secure intake • encrypted submission • GDPR consent</li><li>Forensic normalisation & integrity checks</li></ul><div class="control">UK GDPR-compliant controls apply.</div></div>
-      <div class="card"><h3>AI-Assisted Behavioural Analysis</h3><ul style="padding-left:18px"><li>Sentiment/tone • pattern recognition</li><li>Timeline mapping • anomaly detection</li></ul><div class="control">Analyst validation required before reporting.</div></div>
-      <div class="card"><h3>Human Forensic Review</h3><ul style="padding-left:18px"><li>Independent verification</li><li>Cross-source corroboration</li><li>Defensible methodology</li></ul></div>
+      <div class="card"><h3><a href="services/evidence-handling.html">Evidence Handling & Verification</a></h3><ul style="padding-left:18px"><li>Secure intake • encrypted submission • GDPR consent</li><li>Forensic normalisation & integrity checks</li></ul><div class="control">UK GDPR-compliant controls apply.</div></div>
+      <div class="card"><h3><a href="services/ai-assisted-behavioural-analysis.html">AI-Assisted Behavioural Analysis</a></h3><ul style="padding-left:18px"><li>Sentiment/tone • pattern recognition</li><li>Timeline mapping • anomaly detection</li></ul><div class="control">Analyst validation required before reporting.</div></div>
+      <div class="card"><h3><a href="services/human-forensic-review.html">Human Forensic Review</a></h3><ul style="padding-left:18px"><li>Independent verification</li><li>Cross-source corroboration</li><li>Defensible methodology</li></ul></div>
     </div>
   </section>
 </div>

--- a/services/ai-assisted-behavioural-analysis.html
+++ b/services/ai-assisted-behavioural-analysis.html
@@ -30,11 +30,7 @@
       </div>
     </div>
   </footer>
+  <script defer src="../js/evidence.js"></script>
   <script defer src="../js/theme-toggle.js"></script>
-  <script>
-    function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/services/evidence-handling.html
+++ b/services/evidence-handling.html
@@ -30,11 +30,7 @@
       </div>
     </div>
   </footer>
+  <script defer src="../js/evidence.js"></script>
   <script defer src="../js/theme-toggle.js"></script>
-  <script>
-    function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/services/human-forensic-review.html
+++ b/services/human-forensic-review.html
@@ -30,11 +30,7 @@
       </div>
     </div>
   </footer>
+  <script defer src="../js/evidence.js"></script>
   <script defer src="../js/theme-toggle.js"></script>
-  <script>
-    function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Link each services overview card to its detailed service page for easier navigation.
- Replace brittle inline scripts on service detail pages with shared `evidence.js` logic to avoid missing-element errors and ensure the copyright year renders.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run minify`


------
https://chatgpt.com/codex/tasks/task_e_68c2c9fb9dbc83229c675024a21046d5