### PR TITLE
Fix service page scripts, add navigation links, and rebuild home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,28 +8,57 @@
   <meta name="theme-color" content="#0b132b"/>
   <link rel="stylesheet" href="style.css"/>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
-  <script defer src="js/theme-toggle.js"></script>
 </head>
-<body id="top">
-  <nav>
-    <ul>
-      <li><a href="#top">Home</a></li>
-      <li><a href="#services">Services</a></li>
-      <li><a href="#contact">Contact</a></li>
-    </ul>
-  </nav>
-  <main>
-    <section id="services">
-      <h2>Services</h2>
-      <p>Explore our range of services tailored to your needs.</p>
-    </section>
-    <section id="contact">
-      <h2>Contact</h2>
-      <p><a href="contact.html">Get in touch</a></p>
-    </section>
-  </main>
-  <footer>
-    <p>&copy; 2024 RBIS</p>
-  </footer>
+<body>
+<nav class="nav">
+  <div class="wrap">
+    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <div class="menu">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
+      <a href="dashboards.html">Dashboards</a>
+      <a href="trust.html">Trust</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
+      <button id="themeToggle" class="btn-ghost">Dark Mode</button>
+      <label class="btn-ghost">
+        <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
+      </label>
+    </div>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="wrap">
+    <div>
+      <h1>Behavioural & Intelligence Services</h1>
+      <p>RBIS equips leaders with foresight, clarity, and behavioural advantage through independent analysis and intelligence-grade, court-ready reports.</p>
+      <p><a class="btn" href="services.html">Explore Services</a> <a class="btn-ghost" href="contact.html">Get in touch</a></p>
+    </div>
+    <div><img src="logo.svg" alt=""/></div>
+  </div>
+</header>
+
+<div class="wrap">
+  <section class="section">
+    <h2>Services</h2>
+    <p>Explore our range of services tailored to your needs.</p>
+    <p><a class="btn" href="services.html">View Services</a></p>
+  </section>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>© <span id="year"></span> RBIS — Behavioural & Intelligence Services</div>
+    <div class="footer-links">
+      <a href="legal.html#legal-privacy">Privacy</a><a href="legal.html#legal-cookies">Cookies</a><a href="legal.html#legal-terms">Terms</a><a href="legal.html#legal-security">Security</a><a href="legal.html#legal-retention">Data Retention</a><a href="legal.html#legal-nda">NDA</a><a href="legal.html#legal-claims">Claims</a><a href="legal.html#legal-dpa">DPA</a>
+    </div>
+  </div>
+</footer>
+
+<script src="js/evidence.js"></script>
+<script defer src="js/theme-toggle.js"></script>
 </body>
 </html>
+

--- a/services.html
+++ b/services.html
@@ -32,9 +32,9 @@
   <h1>Services & Solutions</h1>
   <section class="section">
     <div class="grid grid-3">
-      <div class="card"><h3>Evidence Handling & Verification</h3><ul style="padding-left:18px"><li>Secure intake • encrypted submission • GDPR consent</li><li>Forensic normalisation & integrity checks</li></ul><div class="control">UK GDPR-compliant controls apply.</div></div>
-      <div class="card"><h3>AI-Assisted Behavioural Analysis</h3><ul style="padding-left:18px"><li>Sentiment/tone • pattern recognition</li><li>Timeline mapping • anomaly detection</li></ul><div class="control">Analyst validation required before reporting.</div></div>
-      <div class="card"><h3>Human Forensic Review</h3><ul style="padding-left:18px"><li>Independent verification</li><li>Cross-source corroboration</li><li>Defensible methodology</li></ul></div>
+      <div class="card"><h3><a href="services/evidence-handling.html">Evidence Handling & Verification</a></h3><ul style="padding-left:18px"><li>Secure intake • encrypted submission • GDPR consent</li><li>Forensic normalisation & integrity checks</li></ul><div class="control">UK GDPR-compliant controls apply.</div></div>
+      <div class="card"><h3><a href="services/ai-assisted-behavioural-analysis.html">AI-Assisted Behavioural Analysis</a></h3><ul style="padding-left:18px"><li>Sentiment/tone • pattern recognition</li><li>Timeline mapping • anomaly detection</li></ul><div class="control">Analyst validation required before reporting.</div></div>
+      <div class="card"><h3><a href="services/human-forensic-review.html">Human Forensic Review</a></h3><ul style="padding-left:18px"><li>Independent verification</li><li>Cross-source corroboration</li><li>Defensible methodology</li></ul></div>
     </div>
   </section>
 </div>

--- a/services/ai-assisted-behavioural-analysis.html
+++ b/services/ai-assisted-behavioural-analysis.html
@@ -30,11 +30,7 @@
       </div>
     </div>
   </footer>
+  <script defer src="../js/evidence.js"></script>
   <script defer src="../js/theme-toggle.js"></script>
-  <script>
-    function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/services/evidence-handling.html
+++ b/services/evidence-handling.html
@@ -30,11 +30,7 @@
       </div>
     </div>
   </footer>
+  <script defer src="../js/evidence.js"></script>
   <script defer src="../js/theme-toggle.js"></script>
-  <script>
-    function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/services/human-forensic-review.html
+++ b/services/human-forensic-review.html
@@ -30,11 +30,7 @@
       </div>
     </div>
   </footer>
+  <script defer src="../js/evidence.js"></script>
   <script defer src="../js/theme-toggle.js"></script>
-  <script>
-    function toggleEvidenceMode(){const on=document.getElementById('evc').checked; document.body.classList.toggle('evidence-mode', on); localStorage.setItem('rbis_evc', JSON.stringify(!!on));}
-    (function(){try{const st=JSON.parse(localStorage.getItem('rbis_evc')||'false'); document.getElementById('evc').checked=!!st; document.body.classList.toggle('evidence-mode', !!st);}catch{}})();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Link each services overview card to its detailed service page for easier navigation.
- Replace brittle inline scripts on service detail pages with shared `evidence.js` logic to avoid missing-element errors and ensure the copyright year renders.
- Rebuild the minimalist home page with shared navigation, hero content, and footer so the site renders consistently.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run minify`


------
https://chatgpt.com/codex/tasks/task_e_68c2c9fb9dbc83229c675024a21046d5