### PR TITLE
Rebuild navigation and key informational pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,7 @@
 <body>
 <nav class="nav">
   <div class="wrap">
-    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <a href="index.html" class="brand"><img src="logo.svg" alt="RBIS logo"/></a>
     <div class="menu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>

--- a/dashboards.html
+++ b/dashboards.html
@@ -7,5 +7,48 @@
   <meta name="description" content="RBIS dashboards: CEO Command, Board & Crisis, Live Ops, Investor Flight Deck."/>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
   <link rel="stylesheet" href="style.css"/>
-  <script defer src="js/theme-toggle.js"></script>
 </head>
+<body>
+<nav class="nav">
+  <div class="wrap">
+    <a href="index.html" class="brand"><img src="logo.svg" alt="RBIS logo"/></a>
+    <div class="menu">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
+      <a href="dashboards.html">Dashboards</a>
+      <a href="trust.html">Trust</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
+      <button id="themeToggle" class="btn-ghost">Dark Mode</button>
+      <label class="btn-ghost">
+        <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
+      </label>
+    </div>
+  </div>
+</nav>
+
+<div class="wrap">
+  <h1>Executive Dashboards</h1>
+  <section class="section grid grid-2">
+    <div class="card"><h3>CEO Command</h3><p>Top-level performance metrics and risk alerts.</p></div>
+    <div class="card"><h3>Board &amp; Crisis</h3><p>Structured briefings for governance and emergency response.</p></div>
+    <div class="card"><h3>Live Ops</h3><p>Operational telemetry for real-time decision making.</p></div>
+    <div class="card"><h3>Investor Flight Deck</h3><p>Financial and ESG indicators ready for stakeholders.</p></div>
+  </section>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>© <span id="year"></span> RBIS — Behavioural & Intelligence Services</div>
+    <div class="footer-links">
+      <a href="legal.html#legal-privacy">Privacy</a><a href="legal.html#legal-cookies">Cookies</a><a href="legal.html#legal-terms">Terms</a><a href="legal.html#legal-security">Security</a><a href="legal.html#legal-retention">Data Retention</a><a href="legal.html#legal-nda">NDA</a><a href="legal.html#legal-claims">Claims</a><a href="legal.html#legal-dpa">DPA</a>
+    </div>
+  </div>
+</footer>
+
+<script src="js/evidence.js"></script>
+<script defer src="js/theme-toggle.js"></script>
+</body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body>
 <nav class="nav">
   <div class="wrap">
-    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <a href="index.html" class="brand"><img src="logo.svg" alt="RBIS logo"/></a>
     <div class="menu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
@@ -31,12 +31,9 @@
 
 <header class="hero">
   <div class="wrap">
-    <div>
-      <h1>Behavioural & Intelligence Services</h1>
-      <p>RBIS equips leaders with foresight, clarity, and behavioural advantage through independent analysis and intelligence-grade, court-ready reports.</p>
-      <p><a class="btn" href="services.html">Explore Services</a> <a class="btn-ghost" href="contact.html">Get in touch</a></p>
-    </div>
-    <div><img src="logo.svg" alt=""/></div>
+    <h1>Behavioural & Intelligence Services</h1>
+    <p>RBIS equips leaders with foresight, clarity, and behavioural advantage through independent analysis and intelligence-grade, court-ready reports.</p>
+    <p><a class="btn" href="services.html">Explore Services</a> <a class="btn-ghost" href="contact.html">Get in touch</a></p>
   </div>
 </header>
 

--- a/legal.html
+++ b/legal.html
@@ -13,7 +13,7 @@
 <body>
 <nav class="nav">
   <div class="wrap">
-    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <a href="index.html" class="brand"><img src="logo.svg" alt="RBIS logo"/></a>
     <div class="menu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
@@ -51,7 +51,38 @@
       </ul>
     </aside>
     <div>
-      <!-- existing legal articles and content remain unchanged -->
+      <details id="legal-privacy" class="card" open>
+        <summary>Privacy Policy (UK GDPR)</summary>
+        <p>We handle personal data with strict confidentiality and process it under the lawful bases set out in the UK GDPR.</p>
+      </details>
+      <details id="legal-terms" class="card">
+        <summary>Terms of Service</summary>
+        <p>Use of RBIS services and this site is governed by terms requiring lawful use and respect for intellectual property.</p>
+      </details>
+      <details id="legal-nda" class="card">
+        <summary>Mutual NDA</summary>
+        <p>Engagements may include a mutual non-disclosure agreement protecting sensitive information for all parties.</p>
+      </details>
+      <details id="legal-retention" class="card">
+        <summary>Data Retention &amp; Deletion</summary>
+        <p>Evidence and reports are retained only as long as necessary to meet legal and contractual obligations.</p>
+      </details>
+      <details id="legal-security" class="card">
+        <summary>Security &amp; Chain of Custody</summary>
+        <p>All materials are stored and transferred using audited channels to preserve integrity and provenance.</p>
+      </details>
+      <details id="legal-cookies" class="card">
+        <summary>Cookie Policy</summary>
+        <p>Minimal cookies are used for essential functionality; analytics cookies are not employed.</p>
+      </details>
+      <details id="legal-claims" class="card">
+        <summary>Claims &amp; Testimonials</summary>
+        <p>Public statements and endorsements are documented and traceable to verified evidence.</p>
+      </details>
+      <details id="legal-dpa" class="card">
+        <summary>Data Processing Addendum</summary>
+        <p>Standard contractual clauses outline processor duties, subject access, and incident reporting.</p>
+      </details>
     </div>
   </section>
 </div>
@@ -65,5 +96,15 @@
 
 <script src="js/evidence.js"></script>
 <script defer src="js/theme-toggle.js"></script>
+<script>
+function openHash(){
+  if(location.hash){
+    const el = document.querySelector(location.hash);
+    if(el && el.tagName.toLowerCase()==='details'){ el.open = true; }
+  }
+}
+window.addEventListener('hashchange', openHash);
+openHash();
+</script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -11,7 +11,7 @@
 <body>
 <nav class="nav">
   <div class="wrap">
-    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <a href="index.html" class="brand"><img src="logo.svg" alt="RBIS logo"/></a>
     <div class="menu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>

--- a/software.html
+++ b/software.html
@@ -11,7 +11,7 @@
 <body>
 <nav class="nav">
   <div class="wrap">
-    <div class="brand"><img src="logo.svg" alt="RBIS logo"/></div>
+    <a href="index.html" class="brand"><img src="logo.svg" alt="RBIS logo"/></a>
     <div class="menu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>

--- a/style.css
+++ b/style.css
@@ -43,7 +43,7 @@ img{max-width:100%;height:auto}
 /* Navigation */
 .nav{position:sticky;top:0;z-index:50;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
 .nav .wrap{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-.brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:20px;color:var(--brand)}
+.brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:20px;color:var(--brand);text-decoration:none}
 .brand img{height:34px;width:auto}
 .menu{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
 .menu a{padding:8px 10px;border-radius:10px;text-decoration:none;color:var(--ink)}
@@ -93,7 +93,7 @@ img{max-width:100%;height:auto}
 .breadcrumb a{color:var(--accent);text-decoration:none}
 
 header.hero{background:linear-gradient(180deg,#fff,#f3f6fb 56%,#fff);border-bottom:1px solid var(--line)}
-header.hero .wrap{display:grid;grid-template-columns:1.2fr .8fr;gap:26px;padding:56px 0}
+header.hero .wrap{padding:56px 0}
 .hero h1{font-size:clamp(28px,4vw,44px);line-height:1.2;margin:8px 0 10px}
 h1{font-size:clamp(26px,4vw,40px);line-height:1.2;margin:22px 0 12px}
 h2{font-size:clamp(22px,2.6vw,32px);line-height:1.2;margin:26px 0 10px}
@@ -107,7 +107,6 @@ p{margin:0 0 12px;color:var(--muted)}
 .navcol{grid-template-columns:260px 1fr}
 
 @media (max-width:980px){
-  header.hero .wrap{grid-template-columns:1fr}
   .grid-2,.grid-3{grid-template-columns:1fr}
   .navcol{grid-template-columns:1fr}
   .wrap{padding:0 16px}

--- a/trust.html
+++ b/trust.html
@@ -3,9 +3,52 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>RBIS — Trust & Assurance Centre</title>
+  <title>RBIS — Trust &amp; Assurance Centre</title>
   <meta name="description" content="RBIS Trust & Assurance: commitments, compliance matrix, policy ledger, and certified extracts."/>
   <link rel="stylesheet" href="style.css"/>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%230b132b'/%3E%3Ctext x='50' y='70' font-size='70' text-anchor='middle' fill='white'%3ER%3C/text%3E%3C/svg%3E"/>
-  <script defer src="js/theme-toggle.js"></script>
 </head>
+<body>
+<nav class="nav">
+  <div class="wrap">
+    <a href="index.html" class="brand"><img src="logo.svg" alt="RBIS logo"/></a>
+    <div class="menu">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="software.html">Software</a>
+      <a href="dashboards.html">Dashboards</a>
+      <a href="trust.html">Trust</a>
+      <a href="legal.html">Legal</a>
+      <a href="contact.html" class="btn marketing">Contact</a>
+      <button id="themeToggle" class="btn-ghost">Dark Mode</button>
+      <label class="btn-ghost">
+        <input id="evc" type="checkbox" style="accent-color:#1c2541" onchange="toggleEvidenceMode()"> Evidence Mode
+      </label>
+    </div>
+  </div>
+</nav>
+
+<div class="wrap">
+  <h1>Trust &amp; Assurance Centre</h1>
+  <section class="section grid grid-2">
+    <div class="card"><h3>Commitments Ledger</h3><p>Transparent register of service promises and their fulfilment status.</p></div>
+    <div class="card"><h3>Compliance Matrix</h3><p>Mapped obligations across regulators with real-time policy alignment.</p></div>
+    <div class="card"><h3>Policy Repository</h3><p>Version-controlled library of internal procedures and public statements.</p></div>
+    <div class="card"><h3>Certified Extracts</h3><p>Downloadable certificates and audit-ready evidence bundles.</p></div>
+  </section>
+</div>
+
+<footer>
+  <div class="wrap">
+    <div>© <span id="year"></span> RBIS — Behavioural & Intelligence Services</div>
+    <div class="footer-links">
+      <a href="legal.html#legal-privacy">Privacy</a><a href="legal.html#legal-cookies">Cookies</a><a href="legal.html#legal-terms">Terms</a><a href="legal.html#legal-security">Security</a><a href="legal.html#legal-retention">Data Retention</a><a href="legal.html#legal-nda">NDA</a><a href="legal.html#legal-claims">Claims</a><a href="legal.html#legal-dpa">DPA</a>
+    </div>
+  </div>
+</footer>
+
+<script src="js/evidence.js"></script>
+<script defer src="js/theme-toggle.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Make the RBIS logo a clickable link and align navigation branding to the top-left on every page
- Remove oversized landing logo and streamline hero layout
- Restore content pages with intranet-style sections for Legal Hub, Trust Centre, and Executive Dashboards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run minify`


------
https://chatgpt.com/codex/tasks/task_e_68c2cecbbcec8322ac77ef5f99757235