### PR TITLE
Enhance home page and add real dashboard data

### DIFF
--- a/dashboards.html
+++ b/dashboards.html
@@ -36,6 +36,22 @@
     <div class="card"><h3>Live Ops</h3><p>Operational telemetry for real-time decision making.</p></div>
     <div class="card"><h3>Investor Flight Deck</h3><p>Financial and ESG indicators ready for stakeholders.</p></div>
   </section>
+
+  <section class="section">
+    <h2>Industry Benchmarks</h2>
+    <table class="table">
+      <thead>
+        <tr><th>Industry</th><th>Metric</th><th>Value</th><th>Source</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Energy</td><td>Global oil demand 2023</td><td>101.7&nbsp;mb/d</td><td>IEA</td></tr>
+        <tr><td>Cybersecurity</td><td>Average data breach cost</td><td>$4.45M</td><td>IBM 2023</td></tr>
+        <tr><td>Finance</td><td>Non-performing loan ratio</td><td>5.2%</td><td>World Bank 2022</td></tr>
+        <tr><td>Retail</td><td>E-commerce share of retail sales</td><td>19%</td><td>UNCTAD 2023</td></tr>
+      </tbody>
+    </table>
+    <p class="muted">Sources: International Energy Agency, IBM, World Bank, UNCTAD.</p>
+  </section>
 </div>
 
 <footer>

--- a/index.html
+++ b/index.html
@@ -31,13 +31,19 @@
 
 <header class="hero">
   <div class="wrap">
-    <h1>Behavioural & Intelligence Services</h1>
-    <p>RBIS equips leaders with foresight, clarity, and behavioural advantage through independent analysis and intelligence-grade, court-ready reports.</p>
+    <h1>Behavioural &amp; Intelligence Services</h1>
+    <p>Trusted intelligence for confident decisions.</p>
     <p><a class="btn" href="services.html">Explore Services</a> <a class="btn-ghost" href="contact.html">Get in touch</a></p>
   </div>
 </header>
 
 <div class="wrap">
+  <section class="section grid grid-3">
+    <div class="card"><h3>Confidence</h3><p>Decision support grounded in behavioural science.</p></div>
+    <div class="card"><h3>Clarity</h3><p>Clear, concise reporting that cuts through noise.</p></div>
+    <div class="card"><h3>Compliance</h3><p>Evidence built for legal and regulatory scrutiny.</p></div>
+  </section>
+
   <section class="section">
     <h2>Services</h2>
     <p>Explore our range of services tailored to your needs.</p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "minify": "html-minifier-terser --collapse-whitespace --remove-comments --minify-js true --minify-css true --input-dir . --output-dir dist --file-ext html,css"
+    "minify": "html-minifier-terser --collapse-whitespace --remove-comments --minify-js true --minify-css true --input-dir . --output-dir dist --file-ext html,css",
+    "test": "node test.js"
   },
   "devDependencies": {
     "html-minifier-terser": "^7.2.0"

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const index = fs.readFileSync('index.html', 'utf8');
+assert(
+  index.includes('Confidence') && index.includes('Clarity') && index.includes('Compliance'),
+  'Home page missing feature cards'
+);
+
+const dashboards = fs.readFileSync('dashboards.html', 'utf8');
+assert(/\d/.test(dashboards), 'Dashboards page should include numeric industry data');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Refresh home page hero and add feature cards for clearer value messaging
- Populate dashboards with real industry benchmark data
- Introduce basic HTML checks and wire into `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d09c093c83229110448aebf741a9