### PR TITLE
Add workflow to scaffold Next.js TS app

### DIFF
--- a/.github/workflows/scaffold-nextjs-ts.yml
+++ b/.github/workflows/scaffold-nextjs-ts.yml
@@ -1,0 +1,39 @@
+name: Scaffold Next.js TS
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  scaffold:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Create Next.js app
+        run: |
+          npx create-next-app@latest --ts my-app --eslint --app --src-dir --import-alias "@/*" --use-npm
+
+      - name: Move scaffold to repo root (optional)
+        run: |
+          shopt -s dotglob
+          mv my-app/* .
+          rmdir my-app
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b scaffold/nextjs-ts || true
+          git add -A
+          git commit -m "Scaffold Next.js + TypeScript via Actions" || echo "No changes to commit."
+          git push -u origin scaffold/nextjs-ts


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to scaffold Next.js + TypeScript project via `create-next-app`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c35cc3af0c8322ba5300657a4734d4